### PR TITLE
Refs #31 - Adds render() for rendering template strings in set_trace

### DIFF
--- a/docs/_templates/set_trace.rst
+++ b/docs/_templates/set_trace.rst
@@ -15,12 +15,19 @@ Behavior:
 Inside the Debugger
 *******************
 
-Once inside the debugger, one can use details, attributes, and variables as functions as follows::
+Once inside the debugger, one can use details, attributes, variables, and render as functions as follows::
 
     details(variable_name)
     attributes(variable_name)
     variables(context)
+    render(string)
 
+The details, attributes, and variables functions work the same as their template tag counterparts.  For each
+of these, refer to their corresponding pages for more details.
+
+The render function is a quick way to test out how a given template string would be rendered using the
+current context. For instance, typing `render('{{ now }}')` in a set trace will display the rendered string,
+pulling the variable `now` from the current context.
 
 Usages and Examples
 *******************
@@ -41,5 +48,7 @@ A common use case is to put a {% set_trace %} near the top of the template you w
         Out: <SomeObject: identifier_2>
         In: item.attribute
         Out: "Portable Hole"
+        In: render('{% if item.magical %}A magical item {% endif %}')
+        Out: "A magical item"
 
 Using a similar technique, one might place {% set_trace %} inside of loops or conditional blocks to assure these blocks are or are not being executed given certain criteria. For example, if the given scenario causes the containing conditional to evaluate to true, the runserver will drop into a debugger, otherwise template rendering will continue as normal.

--- a/template_debug/templatetags/debug_tags.py
+++ b/template_debug/templatetags/debug_tags.py
@@ -85,10 +85,12 @@ def set_trace(context):
         import pdb
         print("For best results, pip install ipdb.")
     print("Variables that are available in the current context:")
+    render = lambda s: template.Template(s).render(context)
     availables = get_variables(context)
     pprint(availables)
     print('Type `availables` to show this list.')
     print('Type <variable_name> to access one.')
+    print('Use render("template string") to test template rendering')
     # Cram context variables into the local scope
     for var in availables:
         locals()[var] = context[var]
@@ -114,6 +116,7 @@ def pydevd(context):
     except ImportError:
         pdevd_not_available = True
         return ''
+    render = lambda s: template.Template(s).render(context)
     availables = get_variables(context)
     for var in availables:
         locals()[var] = context[var]


### PR DESCRIPTION
As demonstrated in the docs changes, this function is used inside of a
set-trace for the purpose of testing out template rendering of a given
string. For instance, its user might type the following

ipdb> render("""
{% if something %}
    {{ varname.attr|filtername:"arg" }}
{% endif %}
""")

This passes the string through a template.Template and renders it with the
current context.
