### PR TITLE
Fixing {% attributes self %} in python3 environments

### DIFF
--- a/template_debug/utils.py
+++ b/template_debug/utils.py
@@ -73,7 +73,7 @@ def get_attributes(var):
     of a template
     """
     is_valid = partial(is_valid_in_template, var)
-    return filter(is_valid, dir(var))
+    return list(filter(is_valid, dir(var)))
 
 
 def is_valid_in_template(var, attr):


### PR DESCRIPTION
Looks like you were right about the attributes filter being lazy in #35.

This is a patch to fix that part of the problem.
